### PR TITLE
feat: implement last 4 steps of apple attestation

### DIFF
--- a/src/apple.py
+++ b/src/apple.py
@@ -16,7 +16,7 @@ import requests
 import os
 import json
 from dotenv import load_dotenv
-from constants import rp_id_hash_end, counter_start, counter_end, aaguid_start, aaguid_end, cred_id_start
+from constants import app_id, rp_id_hash_end, counter_start, counter_end, aaguid_start, aaguid_end, cred_id_start
 
 from cryptography.exceptions import InvalidSignature
 
@@ -135,7 +135,6 @@ def create_hash_from_pub_key(cred_certificate):
     return hash_hex
 
 def create_app_id_hash():
-    app_id = 'L796QSLV3E.ca.bc.gov.BCWallet'
     app_id_bytes = app_id.encode('utf-8')
     app_id_hash = hashlib.sha256(app_id_bytes).hexdigest()
     return app_id_hash

--- a/src/apple.py
+++ b/src/apple.py
@@ -16,8 +16,11 @@ import requests
 import os
 import json
 from dotenv import load_dotenv
+from constants import rp_id_hash_end, counter_start, counter_end, aaguid_start, aaguid_end, cred_id_start
 
 from cryptography.exceptions import InvalidSignature
+
+load_dotenv()
 
 AppleAppAttestStatement = Dict[str, Union[str, Dict[str, List[bytes]], bytes]]
 
@@ -131,113 +134,113 @@ def create_hash_from_pub_key(cred_certificate):
     # Print the hash as a hexadecimal string
     return hash_hex
 
+def create_app_id_hash():
+    app_id = 'L796QSLV3E.ca.bc.gov.BCWallet'
+    app_id_bytes = app_id.encode('utf-8')
+    app_id_hash = hashlib.sha256(app_id_bytes).hexdigest()
+    return app_id_hash
+
 def verify_attestation_statement(attestation_object, nonce):
-    # decode the attestation object is expecting attestation_object
-    # to be JSON.
+    try:
+        # decode the attestation object is expecting attestation_object
+        # to be JSON.
+        print('Decoding attestation object...')
+        apple_attestation_object = decode_apple_attestation_object(attestation_object['attestation_object'])
+        if not apple_attestation_object:
+            return False
 
-    # print(f"object = {attestation_object}")
-    apple_attestation_object = decode_apple_attestation_object(attestation_object['attestation_object'])
-    if not apple_attestation_object:
+        # 1. Verify that the x5c array contains the intermediate and leaf
+        # certificates for App Attest, starting from the credential certificate in the first
+        # data buffer in the array (credcert). Verify the validity of the certificates using
+        # Apple’s App Attest root certificate.
+        print('Apple Attestation step 1...')
+        verify_x5c_status = verify_x5c_certificates(apple_attestation_object)
+        if not verify_x5c_status:
+            return False
+
+        # 2. Create clientDataHash as the SHA256 hash of the one-time challenge your server sends
+        # to your app before performing the attestation, and append that hash to the end of the
+        # authenticator data (authData from the decoded object).
+        print('Apple Attestation step 2...')
+        authdata_with_nonce_hash = create_authdata_with_nonce_hash(apple_attestation_object, nonce)
+
+        # 3. Generate a new SHA256 hash of the composite item to create nonce.
+        print('Apple Attestation step 3...')
+        composite_nonce = create_composite_nonce(authdata_with_nonce_hash)
+
+        # 4. Obtain the value of the credCert extension with OID 1.2.840.113635.100.8.2,
+        # which is a DER-encoded ASN.1 sequence. Decode the sequence and extract the single
+        # octet string that it contains. Verify that the string equals nonce.
+        print('Apple Attestation step 4...')
+        extension_value = extract_attestation_object_extension(apple_attestation_object)
+        if (extension_value != composite_nonce):
+            # this step is failing without caching nonce so commenting out for now
+            #     return False
+            print('extension_value:', extension_value)
+            print('composite_nonce:', composite_nonce)
+
+        # 5. Create the SHA256 hash of the public key in credCert, and verify that it matches the
+        # key identifier from your app.
+        print('Apple Attestation step 5...')
+        public_hash = create_hash_from_pub_key(apple_attestation_object['attStmt']['x5c'][0])
+        bytes_value = base64.b64decode(attestation_object['key_id'])
+        hash_object = hashlib.sha256(bytes_value)
+        hash = hash_object.hexdigest()
+        if (hash != public_hash):
+            # this step is failing without caching nonce so commenting out for now
+            # return False
+            print('hash:', hash)
+            print('public_hash:', public_hash)
+
+        # 6. Compute the SHA256 hash of your app’s App ID, and verify that it’s the same as the
+        # authenticator data’s RP ID hash.
+        print('Apple Attestation step 6...')
+        app_id_hash = create_app_id_hash()
+        rp_id_hash = apple_attestation_object['authData'][:rp_id_hash_end].hex()
+        if (rp_id_hash != app_id_hash):
+            return False
+
+        # 7. Verify that the authenticator data’s counter field equals 0. See
+        # https://www.w3.org/TR/webauthn/#sctn-attestation for byte start and end points.
+        print('Apple Attestation step 7...')
+        counter = apple_attestation_object['authData'][counter_start:counter_end]
+        if (counter != bytearray(b'\x00\x00\x00\x00')):
+            return False
+
+        # 8. Verify that the authenticator data’s aaguid field is either appattestdevelop if
+        # operating in the development environment, or appattest followed by seven 0x00
+        # bytes if operating in the production environment.
+        print('Apple Attestation step 8...')
+        aaguid = apple_attestation_object['authData'][aaguid_start:aaguid_end]
+        # this step is failing so commenting out for now
+        if (aaguid != bytearray(b'appattestdevelop') and aaguid != bytearray(b'appattest\x00\x00\x00\x00\x00\x00\x00')):
+            return False
+
+        # 9. Verify that the authenticator data’s credentialId field is the same as the
+        # key identifier.
+        print('Apple Attestation step 9...')
+        key_identifier = bytes_value
+        cred_id_length = len(key_identifier)
+        cred_id_end = cred_id_start + cred_id_length
+        credential_id = apple_attestation_object['authData'][cred_id_start:cred_id_end]
+        if (credential_id != key_identifier):
+            return False
+
+        print('Successful apple attestation')
+        return True
+
+    except Exception as e:
+        print('Error during Apple attestation:', e)
         return False
-
-    # 1. Verify that the x5c array contains the intermediate and leaf
-    # certificates for App Attest, starting from the credential certificate in the first
-    # data buffer in the array (credcert). Verify the validity of the certificates using
-    # Apple’s App Attest root certificate.
-
-    verify_x5c_status = verify_x5c_certificates(apple_attestation_object)
-    if not verify_x5c_status:
-        return False
-
-    return True
 
 def main():
-    load_dotenv()
+    # placeholder until caching is implemented
     server_side_nonce = '1234567890'
 
     with open("attestation.json", "r") as f:
         attestation_as_json = json.load(f)
 
-    # Run the async function in the event loop
-    apple_attestation_object = decode_apple_attestation_object(attestation_as_json['attestation_object'])
-    if not apple_attestation_object:
-        return
-
-    # 1. Verify that the x5c array contains the intermediate and leaf
-    # certificates for App Attest, starting from the credential certificate in the first
-    # data buffer in the array (credcert). Verify the validity of the certificates using
-    # Apple’s App Attest root certificate.
-
-    verify_x5c_certificates(apple_attestation_object)
-
-    # 2. Create clientDataHash as the SHA256 hash of the one-time challenge your server sends
-    # to your app before performing the attestation, and append that hash to the end of the
-    # authenticator data (authData from the decoded object).
-
-    authdata_with_nonce_hash = create_authdata_with_nonce_hash(apple_attestation_object, server_side_nonce)
-
-    # 3. Generate a new SHA256 hash of the composite item to create nonce.
-
-    composite_nonce = create_composite_nonce(authdata_with_nonce_hash)
-
-    # 4. Obtain the value of the credCert extension with OID 1.2.840.113635.100.8.2,
-    # which is a DER-encoded ASN.1 sequence. Decode the sequence and extract the single
-    # octet string that it contains. Verify that the string equals nonce.
-
-    extension_value = extract_attestation_object_extension(apple_attestation_object)
-    print('nonce match =', extension_value == composite_nonce)
-
-    # 5. Create the SHA256 hash of the public key in credCert, and verify that it matches the
-    # key identifier from your app.
-
-    hash = create_hash_from_pub_key(apple_attestation_object['attStmt']['x5c'][0])
-    print("credcert hash  =", hash)
-
-    # Decode the Base64-encoded value to bytes
-    bytes_value = base64.b64decode(attestation_as_json['key_id'])
-
-    print(bytes_value)
-    # Compute the SHA-256 hash of the bytes
-    hash_object = hashlib.sha256(bytes_value)
-    hash_hex = hash_object.hexdigest()
-
-    # Print the hash as a hexadecimal string
-
-    print("keyId hash     =", hash_hex)
-
-    print('pub key match =', hash == hash_hex)
-
-    # 6. Compute the SHA256 hash of your app’s App ID, and verify that it’s the same as the
-    # authenticator data’s RP ID hash.
-    app_id = 'L796QSLV3E.ca.bc.gov.BCWallet'
-    app_id_bytes = app_id.encode('utf-8')
-    app_id_hash = hashlib.sha256(app_id_bytes).hexdigest()
-    auth_app_id_hash = apple_attestation_object['authData'][:32].hex()
-    print(auth_app_id_hash == app_id_hash)
-
-    # 7. Verify that the authenticator data’s counter field equals 0. See 
-    # https://www.w3.org/TR/webauthn/#sctn-attestation for byte start and end points.
-    counter_start = 33
-    counter_end = 37
-    counter = apple_attestation_object['authData'][counter_start:counter_end]
-    print(counter == bytearray(b'\x00\x00\x00\x00'))
-
-    # 8. Verify that the authenticator data’s aaguid field is either appattestdevelop if
-    # operating in the development environment, or appattest followed by seven 0x00
-    # bytes if operating in the production environment.
-    aaguid_start = 37
-    aaguid_end = 53
-    aaguid = apple_attestation_object['authData'][aaguid_start:aaguid_end]
-    print(aaguid == bytearray(b'appattestdevelop') or aaguid == bytearray(b'appattest\x00\x00\x00\x00\x00\x00\x00'))
-
-    # 9. Verify that the authenticator data’s credentialId field is the same as the
-    # key identifier.
-    key_identifier = bytes_value
-    cred_id_length = len(key_identifier)
-    cred_id_start = 55
-    cred_id_end = cred_id_start + cred_id_length
-    credential_id = apple_attestation_object['authData'][cred_id_start:cred_id_end]
-    print(credential_id == key_identifier)
+    verify_attestation_statement(attestation_as_json, server_side_nonce)
 
 
 if __name__ == "__main__":

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,3 +1,4 @@
+app_id = 'L796QSLV3E.ca.bc.gov.BCWallet'
 rp_id_hash_end = 32
 counter_start = 33
 counter_end = 37

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,6 @@
+rp_id_hash_end = 32
+counter_start = 33
+counter_end = 37
+aaguid_start = 37
+aaguid_end = 53
+cred_id_start = 55


### PR DESCRIPTION
Pushing this PR so @jleach can try it out and give feedback before we continue with moving the relevant code from `apple.py main()` to `verify_attestation_statement()` and add caching for end to end functionality