### PR TITLE
fix: use redis cache from env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,11 +14,14 @@
   "workspaceFolder": "/work",
   // Install Python and pipenv using pyenv
   // "postCreateCommand": "pip install pipenv && pyenv install 3.11.4 && pyenv global 3.11.4",
-  "postCreateCommand": "pip --disable-pip-version-check --no-cache-dir install -r requirements.txt",
+  "postCreateCommand": "pip --disable-pip-version-check --no-cache-dir install -r requirements.txt && curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash",
   "runArgs": [
     "--env-file",
     ".devcontainer/devcontainer.env"
   ],
+  "containerEnv": {
+    "FLASK_ENV": "development"
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,3 +23,5 @@ services:
     tty: true
     networks:
       - local_network
+    environment:
+      - REDIS_URL=redis://redis:6379/0

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The general command to deploy this to an OpenShift cluster is:
 helm template <RELEASE> ./devops/charts/controller
 --set-string wallet_id=<WALLET_ID> \
 --set-string wallet_key=<WALLET_KEY> \
+--set-string redis_url=<REDIS_URL> \
 --set-file google_oauth_key.json=<PATH_TO_GOOGLE_OAUTH_KEY>| \
 oc apply -n <NAMESPACE> -f -
 ```
@@ -88,6 +89,7 @@ And example command to deploy to the `e79518-dev` namespace is:
 helm template bcwallet ./devops/charts/controller
 --set-string wallet_id=123-456-789 \
 --set-string wallet_key=abc-def-ghi \
+--set-string redis_url=redis://redis:6379/0 \
 --set-file google_oauth_key.json=./google_oauth_key.json| \
 oc apply -n e79518-dev -f -
 ```

--- a/devops/charts/controller/templates/deployment.yaml
+++ b/devops/charts/controller/templates/deployment.yaml
@@ -10,6 +10,7 @@ spec:
   {{- end }}  
   selector:
     matchLabels:
+      app.kubernetes.io/component: controller
       {{- include "attestation-controller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -18,6 +19,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: controller
         {{- include "attestation-controller.labels" . | nindent 8 }}
 	      {{- with .Values.podLabels }}
           {{- toYaml . | nindent 8 }}
@@ -26,7 +28,7 @@ spec:
       volumes:
         - name: google-oauth-key
           secret:
-            secretName: google-oauth-key
+            secretName: {{ include "attestation-controller.fullname" . }}-google-oauth-key
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       containers:
@@ -55,7 +57,9 @@ spec:
           #   timeoutSeconds: 3
           envFrom:
             - secretRef:
-                name: traction-creds
+                name: {{ include "attestation-controller.fullname" . }}-traction-creds
+            - secretRef:
+                name: {{ include "attestation-controller.fullname" . }}-redis-creds
           env:
             - name: PORT
               value: {{.Values.service.targetPort | quote}}

--- a/devops/charts/controller/templates/netpol.yaml
+++ b/devops/charts/controller/templates/netpol.yaml
@@ -15,3 +15,30 @@ spec:
               network.openshift.io/policy-group: ingress
   policyTypes:
     - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{include "attestation-controller.fullname" .}}
+  labels: {{- include "attestation-controller.labels" . | nindent 4}}
+  annotations: {{- toYaml .Values.route.annotations | nindent 4}}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      app.kubernetes.io/instance: shared
+      app.kubernetes.io/name: redis
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 6379
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              {{- include "attestation-controller.selectorLabels" . | nindent 14 }}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+  policyTypes:
+    - Ingress

--- a/devops/charts/controller/templates/secrets.yaml
+++ b/devops/charts/controller/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: google-oauth-key
+  name: {{ include "attestation-controller.fullname" . }}-google-oauth-key
   labels: {{- include "attestation-controller.labels" . | nindent 4}}
 type: Opaque
 data:
@@ -11,9 +11,18 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: traction-creds
+  name: {{ include "attestation-controller.fullname" . }}-traction-creds
   labels: {{- include "attestation-controller.labels" . | nindent 4}}
 type: Opaque
 data:
   TRACTION_WALLET_ID: {{.Values.wallet_id | b64enc}}
   TRACTION_WALLET_KEY: {{.Values.wallet_key | b64enc}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "attestation-controller.fullname" . }}-redis-creds
+  labels: {{- include "attestation-controller.labels" . | nindent 4}}
+type: Opaque
+data:
+  REDIS_URL: {{.Values.redis_url | b64enc}}

--- a/devops/charts/controller/templates/service.yaml
+++ b/devops/charts/controller/templates/service.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{include "attestation-controller.fullname" .}}
-  labels: {{- include "attestation-controller.labels" . | nindent 4}}
+  labels: 
+    app.kubernetes.io/component: controller
+    {{- include "attestation-controller.labels" . | nindent 4}}
 spec:
   ports:
     - port: {{.Values.service.targetPort}}

--- a/fixtures/app_attestation_schema.json
+++ b/fixtures/app_attestation_schema.json
@@ -1,0 +1,13 @@
+{
+    "attributes": [
+        "issue_date_dateint",
+        "validation_method",
+        "app_version",
+        "app_vendor",
+        "app_id",
+        "operating_system",
+        "operating_system_version"
+    ],
+    "schema_name": "app_attestation",
+    "schema_version": "1.0"
+}

--- a/fixtures/test_traction_proof_request.json
+++ b/fixtures/test_traction_proof_request.json
@@ -4,7 +4,10 @@
   "version": "1.0",
   "requested_attributes": {
     "attestationInfo": {
-      "names": ["Assurance Level", "Issued At"],
+      "names": [
+        "Assurance Level",
+        "Issued At"
+      ],
       "restrictions": [
         {
           "schema_id": "J6LCm5Edi9Mi3ASZCqNC1A:2:dev-attestation-schema:1.0",

--- a/scripts/schema.py
+++ b/scripts/schema.py
@@ -1,0 +1,28 @@
+from traction import get_schema, create_schema
+import os
+
+schema_id = "%s:2:app_attestation:1.0" % os.environ.get("TRACTION_LEGACY_DID")
+
+schemas = get_schema(schema_id)
+
+if schemas.get("schema_ids"):
+    print(f"Schema {schema_id} already exists")
+    exit(0)
+
+schema_name = "app_attestation"
+schema_version = "1.0"
+attributes = [
+    "issue_date_dateint",
+    "validation_method",
+    "app_version",
+    "app_vendor",
+    "app_id",
+    "operating_system",
+    "operating_system_version",
+]
+
+created_schema = create_schema(schema_name, schema_version, attributes)
+
+if created_schema:
+    print(f"Schema {schema_id} created successfully")
+    exit(0)

--- a/src/controller.py
+++ b/src/controller.py
@@ -10,41 +10,46 @@ from dotenv import load_dotenv
 from redis_config import redis_instance
 from constants import auto_expire_nonce
 
-load_dotenv()
+if os.getenv("FLASK_ENV") == "development":
+    load_dotenv()
 
 server = Flask(__name__)
 
 def handle_message(message, content):
-    action = content.get('action')
+    action = content.get("action")
     handler = {
-        'request_nonce': handle_request_nonce,
-        'challenge_response': handle_challenge_response,
+        "request_nonce": handle_request_nonce,
+        "challenge_response": handle_challenge_response,
     }.get(action, handle_default)
 
-    return handler(message['connection_id'], content)
+    return handler(message["connection_id"], content)
+
 
 def report_failure(connection_id):
     message_templates_path = os.getenv("MESSAGE_TEMPLATES_PATH")
-    with open(os.path.join(message_templates_path, 'report_failure.json'), 'r') as f:
+    with open(os.path.join(message_templates_path, "report_failure.json"), "r") as f:
         report_failure = json.load(f)
 
     json_str = json.dumps(report_failure)
-    base64_str = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+    base64_str = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
 
     print(f"sending report failure message to {connection_id}")
 
     send_message(connection_id, base64_str)
 
+
 def handle_request_nonce(connection_id, content):
     print("handle_request_nonce")
     connection = get_connection(connection_id)
     print(f"fetched connection = {connection}")
-    if connection['rfc23_state'] != 'completed':
+    if connection["rfc23_state"] != "completed":
         print("connection is not completed")
         return
 
     message_templates_path = os.getenv("MESSAGE_TEMPLATES_PATH")
-    with open(os.path.join(message_templates_path, 'request_attestation.json'), 'r') as f:
+    with open(
+        os.path.join(message_templates_path, "request_attestation.json"), "r"
+    ) as f:
         request_attestation = json.load(f)
 
     nonce = secrets.token_hex(16)
@@ -52,27 +57,28 @@ def handle_request_nonce(connection_id, content):
     # after n seconds
     redis_instance.setex(connection_id, auto_expire_nonce, nonce)
 
-    request_attestation['nonce'] = nonce
+    request_attestation["nonce"] = nonce
     json_str = json.dumps(request_attestation)
-    base64_str = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+    base64_str = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
 
     print(f"sending request attestation message to {connection_id}")
 
     send_message(connection_id, base64_str)
 
+
 def handle_challenge_response(connection_id, content):
     print("handle_attestation_challenge")
 
-    platform = content.get('platform')
+    platform = content.get("platform")
 
     # fetch nonce from cache using connection id as key
     nonce = redis_instance.get(connection_id)
     if not nonce:
-        print('No cached nonce')
+        print("No cached nonce")
         report_failure(connection_id)
         return
 
-    if platform == 'apple':
+    if platform == "apple":
         is_valid_challenge = verify_attestation_statement(content, nonce)
         if is_valid_challenge:
             print("valid apple challenge")
@@ -80,8 +86,8 @@ def handle_challenge_response(connection_id, content):
         else:
             print("invalid apple challenge")
             report_failure(connection_id)
-    elif platform == 'google':
-        token = content.get('attestation_object')
+    elif platform == "google":
+        token = content.get("attestation_object")
         is_valid_challenge = verify_integrity_token(token, nonce)
         if is_valid_challenge:
             print("valid google integrity verdict")
@@ -98,6 +104,7 @@ def handle_default(connection_id, content):
     # Handle default case
     pass
 
+
 def is_base64(s):
     try:
         # Attempt to decode the string as base64
@@ -107,31 +114,34 @@ def is_base64(s):
         # If an exception is raised, the string is not base64 encoded
         return False
 
+
 def decode_base64_to_json(s):
     decoded = base64.b64decode(s)
-    json_str = decoded.decode('utf-8')
+    json_str = decoded.decode("utf-8")
     json_obj = json.loads(json_str)
 
     return json_obj
 
-@server.route('/topic/ping/', methods=['POST'])
+
+@server.route("/topic/ping/", methods=["POST"])
 def ping():
     print("Run POST /ping/")
-    return make_response('', 204)
+    return make_response("", 204)
 
-@server.route('/topic/basicmessages/', methods=['POST'])
+
+@server.route("/topic/basicmessages/", methods=["POST"])
 def basicmessages():
     print("Run POST /topic/basicmessages/")
     message = request.get_json()
-    content = message['content']
+    content = message["content"]
 
     if is_base64(content):
         decoded_content = decode_base64_to_json(content)
-        if decoded_content['type'] == 'attestation':
+        if decoded_content["type"] == "attestation":
             handle_message(message, decoded_content)
 
-    return make_response('', 204)
+    return make_response("", 204)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     server.run(debug=True)

--- a/src/redis_config.py
+++ b/src/redis_config.py
@@ -1,3 +1,7 @@
 import redis
+import os
 
-redis_instance = redis.Redis(host='redis', port=6379, decode_responses=True)
+# Get the Redis URL from environment variables
+redis_url = os.getenv('REDIS_URL')
+
+redis_instance = redis.from_url(redis_url, decode_responses=True)

--- a/src/traction.py
+++ b/src/traction.py
@@ -8,6 +8,7 @@ load_dotenv()
 
 bearer_token = None
 
+
 def fetch_bearer_token():
     global bearer_token
 
@@ -29,10 +30,11 @@ def fetch_bearer_token():
         print("Token fetched successfully")
         response_data = json.loads(response.text)
 
-        bearer_token = response_data['token']
+        bearer_token = response_data["token"]
         return bearer_token
     else:
         print(f"Error fetcing token: {response.status_code}")
+
 
 def get_connection(conn_id):
     base_url = os.environ.get("TRACTION_BASE_URL")
@@ -44,7 +46,7 @@ def get_connection(conn_id):
     headers = {
         "Content-Type": "application/json",
         "accept": "application/json",
-        "Authorization": f"Bearer {token}"
+        "Authorization": f"Bearer {token}",
     }
 
     print(f"Fetching connection {conn_id}")
@@ -59,6 +61,7 @@ def get_connection(conn_id):
 
     return None
 
+
 def send_message(conn_id, content):
     base_url = os.environ.get("TRACTION_BASE_URL")
     endpoint = f"/connections/{conn_id}/send-message"
@@ -69,7 +72,7 @@ def send_message(conn_id, content):
     headers = {
         "Content-Type": "application/json",
         "accept": "application/json",
-        "Authorization": f"Bearer {token}"
+        "Authorization": f"Bearer {token}",
     }
     data = {"content": content}
 
@@ -81,6 +84,7 @@ def send_message(conn_id, content):
         print("Message sent successfully")
     else:
         print(f"Error sending message: {response.status_code}")
+
 
 def offer_attestation_credential(conn_id):
     print("issue_attestation_credential")
@@ -94,14 +98,14 @@ def offer_attestation_credential(conn_id):
     headers = {
         "Content-Type": "application/json",
         "accept": "application/json",
-        "Authorization": f"Bearer {token}"
+        "Authorization": f"Bearer {token}",
     }
 
     message_templates_path = os.getenv("MESSAGE_TEMPLATES_PATH")
-    with open(os.path.join(message_templates_path, 'offer.json'), 'r') as f:
+    with open(os.path.join(message_templates_path, "offer.json"), "r") as f:
         offer = json.load(f)
 
-    offer['connection_id'] = conn_id
+    offer["connection_id"] = conn_id
 
     print(f"Sending offer to {conn_id}, offer = {offer}")
 
@@ -111,3 +115,59 @@ def offer_attestation_credential(conn_id):
         print("Offer sent successfully")
     else:
         print(f"Error sending offer: {response.status_code}")
+
+
+def get_schema(schema_id):
+    print("get_schema")
+
+    base_url = os.environ.get("TRACTION_BASE_URL")
+    endpoint = "/schemas/created"
+    url = urljoin(base_url, endpoint)
+
+    token = fetch_bearer_token()
+
+    headers = {
+        "Content-Type": "application/json",
+        "accept": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+
+    response = requests.get(url, headers=headers, params={"schema_id": schema_id})
+
+    if response.status_code == 200:
+        print("Schema queried successfully")
+    else:
+        print(f"Error quering schema: {response.status_code}")
+
+    return response.json()
+
+
+def create_schema(schema_name, schema_version, attributes):
+    print("create_schema")
+
+    base_url = os.environ.get("TRACTION_BASE_URL")
+    endpoint = "/schemas"
+    url = urljoin(base_url, endpoint)
+
+    token = fetch_bearer_token()
+
+    headers = {
+        "Content-Type": "application/json",
+        "accept": "application/json",
+        "Authorization": f"Bearer {token}",
+    }
+
+    schema = {
+        "schema_name": schema_name,
+        "schema_version": schema_version,
+        "attributes": attributes,
+    }
+
+    response = requests.post(url, headers=headers, data=json.dumps(schema))
+
+    if response.status_code == 200:
+        print("Schema created successfully")
+    else:
+        print(f"Error creating schema: {response.status_code}")
+
+    return response.json()


### PR DESCRIPTION
A few changes in this PR including:

- A few new traction fn for schema management. We cannot create schemas through the Traction UI in prod so we need to do them via code.
- Get the redis URI from an environment variable for better deployments
- Add helm to the devContainer
- Add script to create schemas