### PR TITLE
feat: add support for test environment deployment

### DIFF
--- a/devops/charts/controller/templates/deployment.yaml
+++ b/devops/charts/controller/templates/deployment.yaml
@@ -43,18 +43,18 @@ spec:
             - name: google-oauth-key
               mountPath: {{.Values.env.GOOGLE_AUTH_JSON_PATH }} 
               subPath: {{.Values.env.GOOGLE_AUTH_JSON_PATH | base}}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   periodSeconds: 3
-          # readinessProbe:
-          #   httpGet:
-          #     path: /api/v1/ehlo
-          #     port: http
-          #   initialDelaySeconds: 60
-          #   timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /topic/ping/
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /topic/ping/
+              port: http
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
           envFrom:
             - secretRef:
                 name: {{ include "attestation-controller.fullname" . }}-traction-creds

--- a/devops/charts/controller/templates/hpa.yaml
+++ b/devops/charts/controller/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{include "attestation-controller.fullname" .}}-hpa
+  labels: {{- include "attestation-controller.labels" . | nindent 4}}
+  annotations: {{- toYaml .Values.route.annotations | nindent 4}}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{include "attestation-controller.fullname" .}}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}  

--- a/devops/charts/controller/templates/secrets.yaml
+++ b/devops/charts/controller/templates/secrets.yaml
@@ -17,4 +17,4 @@ type: Opaque
 data:
   TRACTION_TENANT_ID: {{.Values.tenant_id | b64enc}}
   TRACTION_TENANT_API_KEY: {{.Values.tenant_api_key | b64enc}}
-
+  TRACTION_LEGACY_DID: {{.Values.traction_legacy_did | b64enc}}

--- a/devops/charts/controller/values_dev.yaml
+++ b/devops/charts/controller/values_dev.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+autoscaling:
+  enabled: false
+
 podAnnotations: {}
 podLabels: {}
 
@@ -14,13 +17,16 @@ image:
   registry: ghcr.io
   repository: bcgov/mobile-attestation-vc-controller/controller
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "332508f"
+  tag: "80d6bf3"
 
 env:
   TRACTION_BASE_URL: "https://traction-tenant-proxy-dev.apps.silver.devops.gov.bc.ca"
   APPLE_ATTESTATION_ROOT_CA_URL: "https://www.apple.com/certificateauthority/Apple_App_Attestation_Root_CA.pem"
   GOOGLE_AUTH_JSON_PATH: "/opt/controller/google_oauth_key.json"
   MESSAGE_TEMPLATES_PATH: "/opt/fixtures/"
+  # This is needed for Google Play verificaiton to accept
+  # non-production playstore builds.
+  ALLOW_TEST_BUILDS: "false"
 
 resources:
   requests:
@@ -41,12 +47,6 @@ route:
   annotations:
     haproxy.router.openshift.io/timeout: 60s
 
-autoscaling:
-  enabled: false
-#   minReplicas: 1
-#   maxReplicas: 5
-#   targetCPUUtilizationPercentage: 80
-
 # serviceAccount:
 #   # Specifies whether a service account should be created
 #   create: true
@@ -60,14 +60,7 @@ autoscaling:
 
 # Additional volumes on the output Deployment definition.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
 
 # Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
 

--- a/devops/charts/controller/values_dev.yaml
+++ b/devops/charts/controller/values_dev.yaml
@@ -26,7 +26,7 @@ env:
   MESSAGE_TEMPLATES_PATH: "/opt/fixtures/"
   # This is needed for Google Play verificaiton to accept
   # non-production playstore builds.
-  ALLOW_TEST_BUILDS: "false"
+  ALLOW_TEST_BUILDS: "true"
 
 resources:
   requests:

--- a/devops/charts/controller/values_test.yaml
+++ b/devops/charts/controller/values_test.yaml
@@ -1,0 +1,69 @@
+# Default values for attestation-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 80
+
+podAnnotations: {}
+podLabels: {}
+
+image:
+  pullPolicy: IfNotPresent
+  # registry: artifacts.developer.gov.bc.ca/github-docker-remote
+  # repository: bcgov/mobile-attestation-vc-controller/controller
+  registry: ghcr.io
+  repository: bcgov/mobile-attestation-vc-controller/controller
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "80d6bf3"
+
+env:
+  TRACTION_BASE_URL: "https://traction-tenant-proxy-test.apps.silver.devops.gov.bc.ca"
+  APPLE_ATTESTATION_ROOT_CA_URL: "https://www.apple.com/certificateauthority/Apple_App_Attestation_Root_CA.pem"
+  GOOGLE_AUTH_JSON_PATH: "/opt/controller/google_oauth_key.json"
+  MESSAGE_TEMPLATES_PATH: "/opt/fixtures/"
+  # This is needed for Google Play verificaiton to accept
+  # non-production playstore builds.
+  ALLOW_TEST_BUILDS: "false"
+
+resources:
+  requests:
+    memory: 92Mi
+    cpu: 10m
+  limits:
+    memory: 128Mi
+    cpu: 100m
+
+imagePullSecrets:
+  - name: artifactory-regcred
+
+service:
+  targetPort: 5000
+
+route:
+  host: ""
+  annotations:
+    haproxy.router.openshift.io/timeout: 60s
+
+# serviceAccount:
+#   # Specifies whether a service account should be created
+#   create: true
+#   # Automatically mount a ServiceAccount's API credentials?
+#   automount: true
+#   # Annotations to add to the service account
+#   annotations: {}
+#   # The name of the service account to use.
+#   # If not set and create is true, a name is generated using the fullname template
+#   name: ""
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+

--- a/devops/charts/controller/values_test.yaml
+++ b/devops/charts/controller/values_test.yaml
@@ -29,7 +29,7 @@ env:
   MESSAGE_TEMPLATES_PATH: "/opt/fixtures/"
   # This is needed for Google Play verificaiton to accept
   # non-production playstore builds.
-  ALLOW_TEST_BUILDS: "false"
+  ALLOW_TEST_BUILDS: "true"
 
 resources:
   requests:


### PR DESCRIPTION
This PR makes the following changes:

- Add support to deployment manifests for multiple environments;
- Allow google play attestation to accept test builds;
- Add HPA to test deployment
- Add checks for readiness and liveliness probes
- Add traction did env var