### PR TITLE
fix: prevent failure reports from being sent as basic messages

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -141,7 +141,7 @@ def handle_drpc_challenge_response(drpc_response, connection_id):
 
 
 def report_failure(connection_id):
-    pass
+    pass  # Will implement as DRPC once BC Wallet is capable of handling
 
 
 @server.route("/topic/ping/", methods=["POST", "GET"])

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,11 +1,9 @@
-import base64
 import json
 import secrets
 import logging
 import random
 from flask import Flask, request, make_response
 from traction import (
-    send_message,
     send_drpc_response,
     send_drpc_request,
     offer_attestation_credential,
@@ -143,16 +141,7 @@ def handle_drpc_challenge_response(drpc_response, connection_id):
 
 
 def report_failure(connection_id):
-    message_templates_path = os.getenv("MESSAGE_TEMPLATES_PATH")
-    with open(os.path.join(message_templates_path, "report_failure.json"), "r") as f:
-        report_failure = json.load(f)
-
-    json_str = json.dumps(report_failure)
-    base64_str = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
-
-    logger.info(f"sending report failure message to {connection_id}")
-
-    send_message(connection_id, base64_str)
+    pass
 
 
 @server.route("/topic/ping/", methods=["POST", "GET"])

--- a/src/traction.py
+++ b/src/traction.py
@@ -131,30 +131,6 @@ def send_generic_message(conn_id, endpoint, message):
         logger.error(f"Error sending message: {response.status_code} {response.text}")
 
 
-def send_message(conn_id, content):
-    base_url = os.environ.get("TRACTION_BASE_URL")
-    endpoint = f"/connections/{conn_id}/send-message"
-    url = urljoin(base_url, endpoint)
-
-    token = fetch_bearer_token()
-
-    headers = {
-        "Content-Type": "application/json",
-        "accept": "application/json",
-        "Authorization": f"Bearer {token}",
-    }
-    data = {"content": content}
-
-    logger.info(f"Sending message to {conn_id}, message = {content}")
-
-    response = requests.post(url, headers=headers, data=json.dumps(data))
-
-    if response.status_code == 200:
-        logger.info("Message sent successfully")
-    else:
-        logger.error(f"Error sending message: {response.status_code}")
-
-
 def offer_attestation_credential(offer):
     logger.info("issue_attestation_credential")
 


### PR DESCRIPTION
This is an immediate fix to prevent basic messages from being sent on failure. Later on I will implement a drpc message failure report but changes have to be made in the wallet first.