### PR TITLE
refactor: use drpc request and response mechanics

### DIFF
--- a/fixtures/offer.json
+++ b/fixtures/offer.json
@@ -2,7 +2,7 @@
     "auto_issue": true,
     "auto_remove": true,
     "trace": true,
-    "cred_def_id": "NXp6XcGeCR2MviWuY51Dva:3:CL:33557:bcwallet",
+    "cred_def_id": "NXp6XcGeCR2MviWuY51Dva:3:CL:33557:bcwallet_dev",
     "credential_preview": {
         "@type": "issue-credential/1.0/credential-preview",
         "attributes": [

--- a/src/constants.py
+++ b/src/constants.py
@@ -27,7 +27,7 @@ auto_expire_nonce = 60 * 10  # 10 minutes
 
 # Attestation cred def IDs
 attestation_cred_def_ids = [
-    "NXp6XcGeCR2MviWuY51Dva:3:CL:33557:bcwallet",
-    "RycQpZ9b4NaXuT5ZGjXkUE:3:CL:120:bcwallet",
+    "NXp6XcGeCR2MviWuY51Dva:3:CL:33557:bcwallet_dev",
+    "RycQpZ9b4NaXuT5ZGjXkUE:3:CL:120:bcwallet_test",
     "XqaRXJt4sXE6TRpfGpVbGw:3:CL:655:bcwallet",
 ]

--- a/src/controller.py
+++ b/src/controller.py
@@ -57,7 +57,7 @@ def handle_drpc_default(drpc_request, connection_id):
 
 
 def handle_drpc_request_nonce(drpc_request, connection_id):
-    print("handle_request_nonce")
+    logger.info("handle_drpc_request_nonce")
 
     try:
         nonce = secrets.token_hex(16)
@@ -79,7 +79,7 @@ def handle_drpc_request_nonce(drpc_request, connection_id):
 
 
 def handle_drpc_request_challange(drpc_request, connection_id):
-    logger.info("handle_attestation_challenge")
+    logger.info("handle_drpc_request_challange")
 
     attestation_params = drpc_request.get("params")
 
@@ -186,6 +186,7 @@ def ping():
 @server.route("/topic/drpc_request/", methods=["POST"])
 def drpc_request():
     logger.info("Run POST /topic/drpc_request/")
+
     message = request.get_json()
     connection_id = message["connection_id"]
     thread_id = message["thread_id"]

--- a/src/controller.py
+++ b/src/controller.py
@@ -42,7 +42,7 @@ error_codes = {
 def handle_drpc_request(drpc_request, connection_id):
     handler = {
         "request_nonce": handle_drpc_request_nonce,
-        "request_attestation": handle_drpc_request_challange,
+        "request_attestation": handle_drpc_request_attestation,
     }.get(drpc_request["method"], handle_drpc_default)
 
     return handler(drpc_request, connection_id)
@@ -78,8 +78,8 @@ def handle_drpc_request_nonce(drpc_request, connection_id):
     return response
 
 
-def handle_drpc_request_challange(drpc_request, connection_id):
-    logger.info("handle_drpc_request_challange")
+def handle_drpc_request_attestation(drpc_request, connection_id):
+    logger.info("handle_drpc_request_attestation")
 
     attestation_params = drpc_request.get("params")
 

--- a/src/traction.py
+++ b/src/traction.py
@@ -98,6 +98,8 @@ def get_connection(conn_id):
 def send_drpc_response(conn_id, thread_id, response):
     endpoint = f"/drpc/{conn_id}/response"
     message = {"response": response, "thread_id": thread_id}
+    print(f"Sending response to {conn_id}, message = {message}")
+
     send_generic_message(conn_id, endpoint, message)
 
 


### PR DESCRIPTION
This refactor updates the attestation controller to consistently use DRPC request/response mechanics for communication, eliminating the need for a secondary out-of-band request.

Key changes:
1. **Nonce Handling**: The DRPC call now uses the response option to return the nonce.
2. **Attestation Request**: The DRPC response option is used to send the attestation verification status. If verification fails, a meaningful error message is returned.