### PR TITLE
feat: add redis cluster

### DIFF
--- a/devops/charts/controller/templates/deployment.yaml
+++ b/devops/charts/controller/templates/deployment.yaml
@@ -74,5 +74,5 @@ spec:
             - name: REDIS_URI
               valueFrom:
                 secretKeyRef:
-                  name: redis-shared
+                  name: shared-redis-creds
                   key: connection-string

--- a/devops/charts/redis/.helmignore
+++ b/devops/charts/redis/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/devops/charts/redis/Chart.yaml
+++ b/devops/charts/redis/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: redis
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/devops/charts/redis/README.md
+++ b/devops/charts/redis/README.md
@@ -1,0 +1,172 @@
+
+
+### Deploy
+
+Deploy to the selected namespae. Some commands assume you're already in the given namespace. Adjust the name your cluster by replacing `shared` appropriatly.
+
+```console
+helm template shared devops/charts/redis -f devops/charts/redis/values.yaml --set-string password=$(openssl rand -hex 16) --set-string username=$(openssl rand -hex 16) --set-string namespace=$NAMESPACE | oc apply -n $NAMESPACE -f -
+```
+
+You should see the following output:
+
+```console
+networkpolicy.networking.k8s.io/shared-redis-cluster created
+secret/shared-redis-creds created
+configmap/shared-redis created
+service/shared-redis-headless created
+statefulset.apps/shared-redis created
+```
+
+Check all redis pods are running with the command
+
+```console
+oc get pods -l "app.kubernetes.io/component=redis"
+```
+
+You should see output similar to the following:
+
+```console
+NAME             READY   STATUS    RESTARTS   AGE
+shared-redis-0   1/1     Running   0          5m55s
+shared-redis-1   1/1     Running   0          5m11s
+shared-redis-2   1/1     Running   0          4m28s
+shared-redis-3   1/1     Running   0          3m6s
+shared-redis-4   1/1     Running   0          2m30s
+shared-redis-5   1/1     Running   0          112s
+```
+
+If you are re-deploying or updating the cluster, you will want to keep the same password and username.
+
+
+### Create a Cluster
+
+This only needs to be done one time following the initial deployment of the redis cluster. Adjust the name your cluster by replacing `shared` appropriatly.
+
+The number of nodes and the distribution of master and replica nodes in a Redis cluster depend on various factors such as the desired level of availability, redundancy, and performance requirements. Here are some guidelines to help you decide:
+
+**Basic Configuration:***
+Minimum Nodes: A Redis cluster requires at least 6 nodes to ensure high availability with automatic failover.
+3 Master Nodes: Each master node will handle a subset of the data (hash slots).
+3 Replica Nodes: Each master node will have one replica for redundancy.
+Considerations for Node Configuration:
+High Availability: Ensure that each master has at least one replica. This setup provides redundancy and allows for automatic failover if a master node fails.
+Data Distribution: Redis clusters distribute data across master nodes using hash slots. More master nodes mean more granular data distribution.
+Read Scalability: If read operations are high, having multiple replicas can help distribute the read load.
+Fault Tolerance: More replicas increase fault tolerance. If you have a higher tolerance for failures, you can configure more replicas per master.
+
+Basic High Availability:
+
+6 Nodes Total: 3 Masters and 3 Replicas.
+Each master has one replica.
+
+The paremeter `--cluster-replicas 1` is the number of replicas for each master node. Adjust the name your cluster by replacing `shared` appropriatly.
+
+```console
+oc exec -n $(oc project --short) -it shared-redis-0 -- redis-cli -a $(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.password}' | base64 -d) --cluster create --cluster-replicas 1 $(oc get pods -n $(oc project --short) -l "app.kubernetes.io/component=redis" -o jsonpath='{range.items[*]}{.status.podIP}:6379 {end}')
+```
+
+You should see the following output:
+
+```console
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+>>> Performing hash slots allocation on 6 nodes...
+Master[0] -> Slots 0 - 5460
+Master[1] -> Slots 5461 - 10922
+Master[2] -> Slots 10923 - 16383
+Adding replica 10.97.108.183:6379 to 10.97.179.175:6379
+Adding replica 10.97.170.247:6379 to 10.97.181.42:6379
+Adding replica 10.97.176.209:6379 to 10.97.144.215:6379
+M: 5b24aca2206372f42a372f1c55a6957cd8591f34 10.97.179.175:6379
+   slots:[0-5460] (5461 slots) master
+M: f7aed2b23c011533806280692870eacbca23391d 10.97.181.42:6379
+   slots:[5461-10922] (5462 slots) master
+M: 53894e46058104489254719a819d8e1c871aa8ea 10.97.144.215:6379
+   slots:[10923-16383] (5461 slots) master
+S: 9c63539ae8a31fc03860caea0c6bc4a370221ad7 10.97.176.209:6379
+   replicates 53894e46058104489254719a819d8e1c871aa8ea
+S: 787338c9558f666c32ac45f84af5e23cec26fb0b 10.97.108.183:6379
+   replicates 5b24aca2206372f42a372f1c55a6957cd8591f34
+S: 338d7065d323fb2b27bb59d8f77b4764cbf0d92b 10.97.170.247:6379
+   replicates f7aed2b23c011533806280692870eacbca23391d
+Can I set the above configuration? (type 'yes' to accept): yes
+>>> Nodes configuration updated
+>>> Assign a different config epoch to each node
+>>> Sending CLUSTER MEET messages to join the cluster
+Waiting for the cluster to join
+.
+>>> Performing Cluster Check (using node 10.97.179.175:6379)
+M: 5b24aca2206372f42a372f1c55a6957cd8591f34 10.97.179.175:6379
+   slots:[0-5460] (5461 slots) master
+   1 additional replica(s)
+S: 338d7065d323fb2b27bb59d8f77b4764cbf0d92b 10.97.170.247:6379
+   slots: (0 slots) slave
+   replicates f7aed2b23c011533806280692870eacbca23391d
+M: 53894e46058104489254719a819d8e1c871aa8ea 10.97.144.215:6379
+   slots:[10923-16383] (5461 slots) master
+   1 additional replica(s)
+S: 9c63539ae8a31fc03860caea0c6bc4a370221ad7 10.97.176.209:6379
+   slots: (0 slots) slave
+   replicates 53894e46058104489254719a819d8e1c871aa8ea
+S: 787338c9558f666c32ac45f84af5e23cec26fb0b 10.97.108.183:6379
+   slots: (0 slots) slave
+   replicates 5b24aca2206372f42a372f1c55a6957cd8591f34
+M: f7aed2b23c011533806280692870eacbca23391d 10.97.181.42:6379
+   slots:[5461-10922] (5462 slots) master
+   1 additional replica(s)
+[OK] All nodes agree about slots configuration.
+>>> Check for open slots...
+>>> Check slots coverage...
+```
+
+### Status
+
+Check the status of the current cluster. This will show the number of nodes and the number of replicas. The parameter `-i` is any node in the cluster. Adjust the name your cluster by replacing `shared` appropriatly.
+
+
+Check you have the expected number of nodes as described in values.yaml `replicas`.
+
+```console
+oc exec -n $(oc project --short) -i shared-redis-0 -- redis-cli -c CLUSTER NODES
+```
+
+You should see output similar to the following:
+
+```console
+338d7065d323fb2b27bb59d8f77b4764cbf0d92b 10.97.170.247:6379@16379 slave f7aed2b23c011533806280692870eacbca23391d 0 1716930293077 2 connected
+53894e46058104489254719a819d8e1c871aa8ea 10.97.144.215:6379@16379 master - 0 1716930292074 3 connected 10923-16383
+9c63539ae8a31fc03860caea0c6bc4a370221ad7 10.97.176.209:6379@16379 slave 53894e46058104489254719a819d8e1c871aa8ea 0 1716930294082 3 connected
+787338c9558f666c32ac45f84af5e23cec26fb0b 10.97.108.183:6379@16379 slave 5b24aca2206372f42a372f1c55a6957cd8591f34 0 1716930291000 1 connected
+5b24aca2206372f42a372f1c55a6957cd8591f34 10.97.179.175:6379@16379 myself,master - 0 1716930291000 1 connected 0-5460
+f7aed2b23c011533806280692870eacbca23391d 10.97.181.42:6379@16379 master - 0 1716930292000 2 connected 5461-10922
+```
+
+
+
+Confirm the cluster is healthy.
+
+```console
+oc exec -n $(oc project --short) -i shared-redis-0 -- redis-cli -c CLUSTER INFO
+```
+
+You should see output similar to the following:
+
+```console
+cluster_state:ok
+cluster_slots_assigned:16384
+cluster_slots_ok:16384
+cluster_slots_pfail:0
+cluster_slots_fail:0
+cluster_known_nodes:6
+cluster_size:3
+cluster_current_epoch:6
+cluster_my_epoch:1
+cluster_stats_messages_ping_sent:109
+cluster_stats_messages_pong_sent:107
+cluster_stats_messages_sent:216
+cluster_stats_messages_ping_received:102
+cluster_stats_messages_pong_received:109
+cluster_stats_messages_meet_received:5
+cluster_stats_messages_received:216
+total_cluster_links_buffer_limit_exceeded:0
+```

--- a/devops/charts/redis/README.md
+++ b/devops/charts/redis/README.md
@@ -77,7 +77,7 @@ Each master has one replica.
 The paremeter `--cluster-replicas 1` is the number of replicas for each master node. Adjust the name your cluster by replacing `shared` appropriatly.
 
 ```console
-oc exec -n $NAMESPACE -it shared-redis-0 -- redis-cli --user $REDIS_USER -a REDIS_PASSWD --cluster create --cluster-replicas 1 $(oc get pods -n $NAMESPACE -l "app.kubernetes.io/component=redis" -o jsonpath='{range.items[*]}{.status.podIP}:6379 {end}')
+oc exec -n $NAMESPACE -it shared-redis-0 -- redis-cli --user $REDIS_USER -a $REDIS_PASSWD --cluster create --cluster-replicas 1 $(oc get pods -n $NAMESPACE -l "app.kubernetes.io/component=redis" -o jsonpath='{range.items[*]}{.status.podIP}:6379 {end}')
 ```
 
 You should see the following output:

--- a/devops/charts/redis/README.md
+++ b/devops/charts/redis/README.md
@@ -11,6 +11,14 @@ export NAMESPACE=$(oc project --short)
 ```
 
 ```console
+export REDIS_USER=$(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.username}' | base64 -d)
+export REDIS_PWD=$(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.password}' | base64 -d)
+export NAMESPACE=$(oc project --short)
+```
+
+
+
+```console
 helm template shared devops/charts/redis -f devops/charts/redis/values.yaml --set-string password=$REDIS_PWD --set-string username=$REDIS_USER --set-string namespace=$NAMESPACE | oc apply -n $NAMESPACE -f -
 ```
 
@@ -69,7 +77,7 @@ Each master has one replica.
 The paremeter `--cluster-replicas 1` is the number of replicas for each master node. Adjust the name your cluster by replacing `shared` appropriatly.
 
 ```console
-oc exec -n $(oc project --short) -it shared-redis-0 -- redis-cli -a $(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.password}' | base64 -d) --cluster create --cluster-replicas 1 $(oc get pods -n $(oc project --short) -l "app.kubernetes.io/component=redis" -o jsonpath='{range.items[*]}{.status.podIP}:6379 {end}')
+oc exec -n $(oc project --short) -it shared-redis-0 -- redis-cli --user $(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.username}' | base64 -d) -a $(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.password}' | base64 -d) --cluster create --cluster-replicas 1 $(oc get pods -n $(oc project --short) -l "app.kubernetes.io/component=redis" -o jsonpath='{range.items[*]}{.status.podIP}:6379 {end}')
 ```
 
 You should see the following output:
@@ -152,7 +160,7 @@ f7aed2b23c011533806280692870eacbca23391d 10.97.181.42:6379@16379 master - 0 1716
 Confirm the cluster is healthy.
 
 ```console
-oc exec -n $(oc project --short) -i shared-redis-0 -- redis-cli -c CLUSTER INFO
+oc exec -n $(oc project --short) -i shared-redis-0 -- redis-cli --user $(oc get secret -n $(oc project --short) shared-redis-creds -o jsonpath='{.data.username}' | base64 -d) -c CLUSTER INFO
 ```
 
 You should see output similar to the following:

--- a/devops/charts/redis/README.md
+++ b/devops/charts/redis/README.md
@@ -5,7 +5,13 @@
 Deploy to the selected namespae. Some commands assume you're already in the given namespace. Adjust the name your cluster by replacing `shared` appropriatly.
 
 ```console
-helm template shared devops/charts/redis -f devops/charts/redis/values.yaml --set-string password=$(openssl rand -hex 16) --set-string username=$(openssl rand -hex 16) --set-string namespace=$NAMESPACE | oc apply -n $NAMESPACE -f -
+export REDIS_USER=$(openssl rand -hex 16)
+export REDIS_PWD=$(openssl rand -hex 16)
+export NAMESPACE=$(oc project --short)
+```
+
+```console
+helm template shared devops/charts/redis -f devops/charts/redis/values.yaml --set-string password=$REDIS_PWD --set-string username=$REDIS_USER --set-string namespace=$NAMESPACE | oc apply -n $NAMESPACE -f -
 ```
 
 You should see the following output:

--- a/devops/charts/redis/templates/_helpers.tpl
+++ b/devops/charts/redis/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redis.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redis.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redis.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redis.labels" -}}
+helm.sh/chart: {{ include "redis.chart" . }}
+{{ include "redis.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "redis.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redis.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redis.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "redis.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/devops/charts/redis/templates/configmap.yaml
+++ b/devops/charts/redis/templates/configmap.yaml
@@ -1,0 +1,19 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{include "redis.fullname" .}}
+  labels: {{- include "redis.labels" . | nindent 4}}
+data:
+  update-ip.sh: |-
+    #!/bin/sh
+    CLUSTER_CONFIG=/data/nodes.conf
+    if [ -f $CLUSTER_CONFIG ]; then
+      if [ -z $POD_IP ]; then
+        echo Unable to determine Pod IP address!
+        exit 1
+      fi
+      echo Updating my IP to $POD_IP in $CLUSTER_CONFIG
+      sed -i.bak -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/$POD_IP/" $CLUSTER_CONFIG
+    fi
+    exec $@

--- a/devops/charts/redis/templates/netpol.yaml
+++ b/devops/charts/redis/templates/netpol.yaml
@@ -1,0 +1,26 @@
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{include "redis.fullname" .}}-cluster
+  labels: {{- include "redis.labels" . | nindent 4}}
+  annotations: {{- toYaml .Values.route.annotations | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      {{- include "redis.selectorLabels" . | nindent 6 }}
+  ingress:
+    - ports:
+      - protocol: TCP
+        port: 16379
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: redis
+              {{- include "redis.selectorLabels" . | nindent 14 }}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+  policyTypes:
+    - Ingress

--- a/devops/charts/redis/templates/netpol.yaml
+++ b/devops/charts/redis/templates/netpol.yaml
@@ -13,7 +13,11 @@ spec:
   ingress:
     - ports:
       - protocol: TCP
-        port: 16379
+        {{- range $name, $port := .Values.service }}
+        {{- if eq .name "gossip" }}
+        port: {{ .port }}
+        {{- end }}
+        {{- end }}
     - from:
         - podSelector:
             matchLabels:

--- a/devops/charts/redis/templates/service.yaml
+++ b/devops/charts/redis/templates/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redis.fullname" . }}-headless
+  labels: {{- include "redis.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    {{- range $name, $port := .Values.service }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: TCP
+    {{- end }}  
+  selector: 
+    app.kubernetes.io/component: redis
+    {{- include "redis.selectorLabels" . | nindent 4 }}
+  

--- a/devops/charts/redis/templates/statefulset.yaml
+++ b/devops/charts/redis/templates/statefulset.yaml
@@ -51,13 +51,13 @@ spec:
                 command:
                   - /bin/sh
                   - -c
-                  - redis-cli -h $HOSTNAME shutdown save
+                  - redis-cli --user $REDISCLI_USER -h $HOSTNAME shutdown save
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
-                - test $(redis-cli -h $HOSTNAME ping) == PONG
+                - test $(redis-cli --user $REDISCLI_USER -h $HOSTNAME ping) == PONG
             initialDelaySeconds: 10
             timeoutSeconds: 1
             failureThreshold: 3
@@ -66,7 +66,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - test $(redis-cli -h $HOSTNAME ping) == PONG
+                - test $(redis-cli --user $REDISCLI_USER -h $HOSTNAME ping) == PONG
             initialDelaySeconds: 15
             timeoutSeconds: 1
             failureThreshold: 3
@@ -83,6 +83,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: password
+                  name:  {{include "redis.fullname" .}}-creds
+            - name: REDISCLI_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
                   name:  {{include "redis.fullname" .}}-creds
           volumeMounts:
             - name: data-vol

--- a/devops/charts/redis/templates/statefulset.yaml
+++ b/devops/charts/redis/templates/statefulset.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{include "redis.fullname" .}}
+  labels: {{- include "redis.labels" . | nindent 4}}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}  
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+      {{- include "redis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: redis
+        {{- include "redis.labels" . | nindent 8 }}
+	      {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      volumes:
+        - name: redis-conf
+          secret:
+            secretName: {{include "redis.fullname" .}}-creds
+        - name: script-vol
+          configMap:
+            name: {{include "redis.fullname" .}}
+            defaultMode: 0755
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            {{- range $name, $port := .Values.service }}
+            - name: {{ .name }}
+              containerPort: {{ .port }}
+            {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - redis-cli -h $HOSTNAME shutdown save
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test $(redis-cli -h $HOSTNAME ping) == PONG
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - test $(redis-cli -h $HOSTNAME ping) == PONG
+            initialDelaySeconds: 15
+            timeoutSeconds: 1
+            failureThreshold: 3
+          command:
+            - /script/update-ip.sh
+            - redis-server
+            - /conf/redis.conf
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name:  {{include "redis.fullname" .}}-creds
+          volumeMounts:
+            - name: data-vol
+              mountPath: /data
+            - name: redis-conf
+              mountPath: /conf/redis.conf
+              subPath: redis.conf
+              readOnly: true
+            - name: script-vol
+              mountPath: /script
+  volumeClaimTemplates:
+    - kind: PersistentVolumeClaim
+      apiVersion: v1
+      metadata:
+        name: data-vol
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.dataVolumeSize }}
+        volumeMode: Filesystem

--- a/devops/charts/redis/values.yaml
+++ b/devops/charts/redis/values.yaml
@@ -1,0 +1,59 @@
+# Default values for attestation-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 6
+
+autoscaling:
+  enabled: false
+
+podAnnotations: {}
+podLabels: {}
+
+image:
+  pullPolicy: Always
+  registry: artifacts.developer.gov.bc.ca/docker-remote
+  repository: redis
+  tag: "7-alpine"
+
+resources:
+  requests:
+    memory: 64Mi
+    cpu: 10m
+  limits:
+    memory: 128Mi
+    cpu: 100m
+
+dataVolumeSize: "32Mi"
+
+imagePullSecrets:
+  - name: artifactory-regcred
+
+service:
+  - name: gossip
+    port: 16379
+  - name: redis
+    port: 6379
+
+route:
+  host: ""
+  annotations:
+    haproxy.router.openshift.io/timeout: 60s
+
+# serviceAccount:
+#   # Specifies whether a service account should be created
+#   create: true
+#   # Automatically mount a ServiceAccount's API credentials?
+#   automount: true
+#   # Annotations to add to the service account
+#   annotations: {}
+#   # The name of the service account to use.
+#   # If not set and create is true, a name is generated using the fullname template
+#   name: ""
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+


### PR DESCRIPTION
We need to deploy the controller to a namespace that does not have Redis installed. To fix this, I've added a Redis Helm chart based on the [original OpenShift deployment](https://github.com/bcgov/openshift-aries-mediator-service/blob/main/openshift/templates/redis/redis-cluster-deploy.yaml). The only significant difference is I took the opportunity to rename the default Redis user from `default` to whatever is supplied by the user. Here are a few good reason to change it:

**Security Risk**: The default user is well-known and can be a target for attackers if the password is weak or not properly secured.
**Lack of Granularity**: Using a single default user does not allow for fine-grained access control or permissions, which can be crucial for larger, more complex environments.
**Compliance Issues**: Depending on your organizational policies or regulatory requirements, using the default user might not meet security and compliance standards.
