### PR TITLE
fix: remove cpu limits

### DIFF
--- a/devops/charts/controller/values_dev.yaml
+++ b/devops/charts/controller/values_dev.yaml
@@ -40,7 +40,6 @@ resources:
     cpu: 10m
   limits:
     memory: 128Mi
-    cpu: 100m
 
 imagePullSecrets:
   - name: artifactory-regcred

--- a/devops/charts/controller/values_prod.yaml
+++ b/devops/charts/controller/values_prod.yaml
@@ -43,7 +43,6 @@ resources:
     cpu: 10m
   limits:
     memory: 128Mi
-    cpu: 100m
 
 imagePullSecrets:
   - name: artifactory-regcred

--- a/devops/charts/controller/values_test.yaml
+++ b/devops/charts/controller/values_test.yaml
@@ -43,7 +43,6 @@ resources:
     cpu: 10m
   limits:
     memory: 128Mi
-    cpu: 100m
 
 imagePullSecrets:
   - name: artifactory-regcred


### PR DESCRIPTION
As of December 2024 vCPU limits are not longer required and have become artificial upper limits for CPU usage. Removing to allow more flexibility. 